### PR TITLE
Prevent deleted flags from appearing in find, fineOne, and populate results

### DIFF
--- a/lib/actionUtil.js
+++ b/lib/actionUtil.js
@@ -65,6 +65,14 @@ module.exports = function(request, options) {
             _options.populateLimit ||
             _options.limit ||
             DEFAULT_POPULATE_LIMIT;
+
+          var opts = {limit: populationLimit};
+          // If the deleted flag is set, make sure those results aren't being included
+          if(_options.deletedFlag) {
+            var values = {};
+            values[_options.deletedAttr] = { '!': _options.deletedValue };
+            _.merge(opts, {where: values});
+          }
             
           return query.populate(association.alias, {limit: populationLimit});
         

--- a/lib/actionUtil.js
+++ b/lib/actionUtil.js
@@ -74,7 +74,7 @@ module.exports = function(request, options) {
             _.merge(opts, {where: values});
           }
             
-          return query.populate(association.alias, {limit: populationLimit});
+          return query.populate(association.alias, opts);
         
         } else {
           
@@ -226,6 +226,13 @@ module.exports = function(request, options) {
   
       // Merge w/ options.where and return
       where = _.merge({}, options.where || {}, where) || undefined;
+
+      // If the deleted flag is set, make sure those results aren't being included
+      if(options.deletedFlag) {
+        var values = {};
+        values[options.deletedAttr] = { '!': options.deletedValue };
+        _.merge(where, values);
+      }
       
       // Deal with ownership
       if (options.actAsUser && options.requireOwner) {

--- a/lib/actionUtil.js
+++ b/lib/actionUtil.js
@@ -32,7 +32,7 @@ module.exports = function(request, options) {
       var _options = options;
       var aliasFilter = request.query.populate;
       var shouldPopulate = _options.populate;
-      
+
       // Convert the string representation of the filter list to an Array. We
       // need this to provide flexibility in the request param. This way both
       // list string representations are supported:
@@ -227,12 +227,7 @@ module.exports = function(request, options) {
       // Merge w/ options.where and return
       where = _.merge({}, options.where || {}, where) || undefined;
 
-      // If the deleted flag is set, make sure those results aren't being included
-      if(options.deletedFlag) {
-        var values = {};
-        values[options.deletedAttr] = { '!': options.deletedValue };
-        _.merge(where, values);
-      }
+      where = _.merge(where, this.checkDeletedFlag());
       
       // Deal with ownership
       if (options.actAsUser && options.requireOwner) {
@@ -382,6 +377,22 @@ module.exports = function(request, options) {
       if (skip) { skip = +skip; }
       
       return skip;
+    },
+
+
+    /**
+     * Determine whether or not the deletedFlag should be included in where clause.
+     * @return {Object}
+     */
+    checkDeletedFlag: function() {
+      // If the deleted flag is set, make sure those results aren't being included
+      if(options.deletedFlag) {
+        var values = {};
+        values[options.deletedAttr] = { '!': options.deletedValue };
+        return values||{};
+      } else {
+        return {};
+      }
     },
   
   

--- a/lib/actions/findOne.js
+++ b/lib/actions/findOne.js
@@ -29,7 +29,7 @@ module.exports = function findOneRecord (route, options) {
       return reply(Boom.wrap(e)); 
     }
     
-    var query = Model.findOne(pk);
+    var query = Model.findOne(pk).where(actionUtil.parseCriteria());
     
     query = actionUtil.populateEach(query);
     

--- a/lib/actions/findOne.js
+++ b/lib/actions/findOne.js
@@ -29,7 +29,7 @@ module.exports = function findOneRecord (route, options) {
       return reply(Boom.wrap(e)); 
     }
     
-    var query = Model.findOne(pk).where(actionUtil.parseCriteria());
+    var query = Model.findOne(pk).where(actionUtil.checkDeletedFlag());
     
     query = actionUtil.populateEach(query);
     


### PR DESCRIPTION
@devinivy This keeps those soft deletes from appearing in all **find** results. Let me know if you think I should add the ```parseCriteria``` to the **update** and **destroy** actions as well.